### PR TITLE
domain+repo+rest

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -21,10 +21,10 @@
     </parent>
     
     <dependencies>
-        <dependency>
+        <!--<dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
-        </dependency>
+        </dependency>-->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -32,6 +32,10 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-rest</artifactId>
         </dependency>
         
         <!-- Database -->

--- a/server/src/main/java/wepa/controller/DefaultController.java
+++ b/server/src/main/java/wepa/controller/DefaultController.java
@@ -7,8 +7,9 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @Controller
 public class DefaultController {
 
+    
     @ResponseBody
-    @RequestMapping("*")
+    @RequestMapping("/hello")
     public String handleDefault() {
         return "Hello World!";
     }

--- a/server/src/main/java/wepa/domain/Account.java
+++ b/server/src/main/java/wepa/domain/Account.java
@@ -1,0 +1,39 @@
+
+package wepa.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.ManyToMany;
+import javax.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Length;
+import org.springframework.data.jpa.domain.AbstractPersistable;
+
+@Entity
+public class Account extends AbstractPersistable<Long> {
+
+    @Column(unique=true)
+    @NotNull
+    @Length(min = 4, max = 255)
+    private String username;
+    @NotNull
+    @Length(min = 6, max = 255)
+    private String password;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+    
+    
+}

--- a/server/src/main/java/wepa/domain/Comment.java
+++ b/server/src/main/java/wepa/domain/Comment.java
@@ -1,0 +1,59 @@
+
+package wepa.domain;
+
+import java.util.Date;
+import javax.persistence.Entity;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import javax.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Length;
+import org.springframework.data.jpa.domain.AbstractPersistable;
+
+@Entity
+public class Comment extends AbstractPersistable<Long> {
+
+    @NotNull
+    private Event event;
+    @NotNull
+    private Account poster;
+    @NotNull
+    @Length(min = 1, max = 200)
+    private String message;
+    @NotNull
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date posted;
+
+    public Event getEvent() {
+        return event;
+    }
+
+    public void setEvent(Event event) {
+        this.event = event;
+    }
+
+    public Account getPoster() {
+        return poster;
+    }
+
+    public void setPoster(Account poster) {
+        this.poster = poster;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public Date getPosted() {
+        return posted;
+    }
+
+    public void setPosted(Date posted) {
+        this.posted = posted;
+    }
+    
+    
+}

--- a/server/src/main/java/wepa/domain/Event.java
+++ b/server/src/main/java/wepa/domain/Event.java
@@ -1,0 +1,82 @@
+
+package wepa.domain;
+
+import java.util.Date;
+import javax.persistence.Entity;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import javax.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Length;
+import org.springframework.data.jpa.domain.AbstractPersistable;
+
+@Entity
+public class Event extends AbstractPersistable<Long> {
+    
+    @NotNull
+    private Account owner;
+    //private List<Account> participants;
+    @NotNull
+    @Length(min = 2, max = 40)
+    private String title;
+    @NotNull
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date startTime;
+    @NotNull
+    @Temporal(TemporalType.TIMESTAMP)
+    private Date endTime;
+    @NotNull
+    @Length(min = 4, max = 40)
+    private String Place;
+    @Length(max = 200)
+    private String Description;
+
+    public Date getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(Date startTime) {
+        this.startTime = startTime;
+    }
+
+    public Date getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(Date endTime) {
+        this.endTime = endTime;
+    }
+
+    public Account getOwner() {
+        return owner;
+    }
+
+    public void setOwner(Account owner) {
+        this.owner = owner;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getPlace() {
+        return Place;
+    }
+
+    public void setPlace(String Place) {
+        this.Place = Place;
+    }
+
+    public String getDescription() {
+        return Description;
+    }
+
+    public void setDescription(String Description) {
+        this.Description = Description;
+    }
+    
+    
+}

--- a/server/src/main/java/wepa/domain/Friendship.java
+++ b/server/src/main/java/wepa/domain/Friendship.java
@@ -1,0 +1,46 @@
+
+package wepa.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.OneToOne;
+import javax.validation.constraints.NotNull;
+import org.springframework.data.jpa.domain.AbstractPersistable;
+
+@Entity
+public class Friendship extends AbstractPersistable<Long> {
+    
+    @NotNull
+    @OneToOne
+    private Account account1;
+    @NotNull
+    @OneToOne
+    private Account account2;
+    @NotNull
+    private boolean accepted;
+
+    public Account getAccount1() {
+        return account1;
+    }
+
+    public void setAccount1(Account account1) {
+        this.account1 = account1;
+    }
+
+    public Account getAccount2() {
+        return account2;
+    }
+
+    public void setAccount2(Account account2) {
+        this.account2 = account2;
+    }
+
+    public boolean isAccepted() {
+        return accepted;
+    }
+
+    public void setAccepted(boolean accepted) {
+        this.accepted = accepted;
+    }
+    
+    
+}

--- a/server/src/main/java/wepa/domain/Participant.java
+++ b/server/src/main/java/wepa/domain/Participant.java
@@ -1,0 +1,43 @@
+
+package wepa.domain;
+
+import javax.persistence.Entity;
+import javax.validation.constraints.NotNull;
+import org.springframework.data.jpa.domain.AbstractPersistable;
+
+@Entity
+public class Participant extends AbstractPersistable<Long> {
+
+    @NotNull
+    private Event event;
+    @NotNull
+    private Account account;
+    @NotNull
+    private boolean accepted;
+
+    public Event getEvent() {
+        return event;
+    }
+
+    public void setEvent(Event event) {
+        this.event = event;
+    }
+
+    public Account getAccount() {
+        return account;
+    }
+
+    public void setAccount(Account account) {
+        this.account = account;
+    }
+
+    public boolean isAccepted() {
+        return accepted;
+    }
+
+    public void setAccepted(boolean accepted) {
+        this.accepted = accepted;
+    }
+    
+    
+}

--- a/server/src/main/java/wepa/repository/AccountRepository.java
+++ b/server/src/main/java/wepa/repository/AccountRepository.java
@@ -1,0 +1,9 @@
+
+package wepa.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import wepa.domain.Account;
+
+public interface AccountRepository extends JpaRepository<Account, Long> {
+
+}

--- a/server/src/main/java/wepa/repository/CommentRepository.java
+++ b/server/src/main/java/wepa/repository/CommentRepository.java
@@ -1,0 +1,9 @@
+
+package wepa.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import wepa.domain.Comment;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+}

--- a/server/src/main/java/wepa/repository/EventRepository.java
+++ b/server/src/main/java/wepa/repository/EventRepository.java
@@ -1,0 +1,9 @@
+
+package wepa.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import wepa.domain.Event;
+
+public interface EventRepository extends JpaRepository<Event, Long> {
+
+}

--- a/server/src/main/java/wepa/repository/FriendshipRepository.java
+++ b/server/src/main/java/wepa/repository/FriendshipRepository.java
@@ -1,0 +1,9 @@
+
+package wepa.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import wepa.domain.Friendship;
+
+public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
+
+}

--- a/server/src/main/java/wepa/repository/ParticipantRepository.java
+++ b/server/src/main/java/wepa/repository/ParticipantRepository.java
@@ -1,0 +1,9 @@
+
+package wepa.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import wepa.domain.Participant;
+
+public interface ParticipantRepository extends JpaRepository<Participant, Long> {
+
+}


### PR DESCRIPTION
Alustavat domainin luokat, repot ja automaattisen spring data restin kokeilu.

Tultiin siihen tulokseen, että on parempi poistaa date taulu ja lisätä viidenneksi tauluksi kommentit eventteihin. Päivämäärät varmaankin paremmin saatavilla suoraan eventistä.